### PR TITLE
Enabling build by opening java modules

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -193,6 +193,9 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
+                    <configuration>
+                        <argLine>--add-opens java.base/java.lang=ALL-UNNAMED</argLine>
+                    </configuration>
                     <version>3.0.0-M5</version>
                 </plugin>
                 <plugin>


### PR DESCRIPTION
Change pom to allow maven-surefire-plugin to do reflection across modules